### PR TITLE
Add C-states management mico-service

### DIFF
--- a/gc-controller/.gitignore
+++ b/gc-controller/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/gc-controller/api/routes.go
+++ b/gc-controller/api/routes.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"github.com/crunchycookie/openstack-gc/gc-controller/route-handler"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func loadRoutes() *chi.Mux {
+	router := chi.NewRouter()
+	router.Use(middleware.Logger)
+
+	router.Route("/idle-states", loadIdleStatesRoutes)
+
+	return router
+}
+
+func loadIdleStatesRoutes(router chi.Router) {
+	idleStatesRoutesHandler := &route_handler.IdleStatesRoutesHandler{}
+
+	router.Get("/", idleStatesRoutesHandler.ListAvailableIdleStates)
+}

--- a/gc-controller/api/service.go
+++ b/gc-controller/api/service.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type Service struct {
+	router http.Handler
+}
+
+func New() *Service {
+	service := &Service{
+		router: loadRoutes(),
+	}
+	return service
+}
+
+func (a *Service) Start(ctx context.Context) error {
+	server := &http.Server{
+		Addr:    ":3000",
+		Handler: a.router,
+	}
+
+	err := server.ListenAndServe()
+	if err != nil {
+		return fmt.Errorf("failed to start the service: %w", err)
+	}
+
+	return nil
+}

--- a/gc-controller/go.mod
+++ b/gc-controller/go.mod
@@ -1,3 +1,5 @@
 module github.com/crunchycookie/openstack-gc/gc-controller
 
 go 1.21.4
+
+require github.com/go-chi/chi/v5 v5.0.11

--- a/gc-controller/go.sum
+++ b/gc-controller/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.0.11 h1:BnpYbFZ3T3S1WMpD79r7R5ThWX40TaFB7L31Y8xqSwA=
+github.com/go-chi/chi/v5 v5.0.11/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/gc-controller/main.go
+++ b/gc-controller/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/crunchycookie/openstack-gc/gc-controller/api"
+)
+
+func main() {
+	service := api.New()
+
+	err := service.Start(context.TODO())
+	if err != nil {
+		fmt.Println("Error while starting the controller service")
+	}
+}

--- a/gc-controller/route-handler/idle-states-routes.go
+++ b/gc-controller/route-handler/idle-states-routes.go
@@ -1,0 +1,12 @@
+package route_handler
+
+import (
+	"net/http"
+)
+
+type IdleStatesRoutesHandler struct {
+}
+
+func (o *IdleStatesRoutesHandler) ListAvailableIdleStates(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Idle states analysis is yet to be implemented"))
+}


### PR DESCRIPTION
Fixes #3.

Builds a Go micro-service that is able to change CPU c-states upon REST requests.